### PR TITLE
Make it API compatible with the existing vga crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Steve Klabnik <steve@steveklabnik.com>"]
 
 [dependencies]
+spin = "0.4.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,17 @@
 #![no_std]
+#![feature(const_fn)]
+
+extern crate spin;
 
 use core::fmt;
 use core::fmt::Write;
 
 mod color;
 use color::Color;
+
+mod print;
+
+use spin::Mutex;
 
 const ROWS: usize = 25;
 const COLS: usize = 80;
@@ -15,6 +22,8 @@ pub struct Vga {
     buffer: [u8; ROWS * COL_BYTES],
     position: usize,
 }
+
+unsafe impl Send for Vga {}
 
 impl Vga {
     pub unsafe fn new(location: *mut u8) -> Vga {
@@ -79,6 +88,14 @@ impl Write for Vga {
         Ok(())
     }
 }
+
+pub static BUFFER: Mutex<Vga> = Mutex::new(
+    Vga {
+        location: 0xb8000 as *mut u8,
+        buffer: [0; ROWS * COL_BYTES],
+        position: 0,
+    }
+);
 
 #[cfg(test)]
 mod tests {

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,0 +1,29 @@
+/// Prints something to the screen, with a trailing newline.
+///
+/// # Examples
+///
+/// ```ignore
+/// kprintln!("Hello, world!");
+/// ```
+#[macro_export]
+macro_rules! kprintln {
+    ($fmt:expr) => (kprint!(concat!($fmt, "\n")));
+    ($fmt:expr, $($arg:tt)*) => (kprint!(concat!($fmt, "\n"), $($arg)*));
+}
+
+/// Prints something to the screen.
+///
+/// # Examples
+///
+/// ```ignore
+/// kprint!("Hello, world!");
+/// ```
+#[macro_export]
+macro_rules! kprint {
+    ($($arg:tt)*) => ({
+        use core::fmt::Write;
+        let mut b = $crate::BUFFER.lock();
+        b.write_fmt(format_args!($($arg)*)).unwrap();
+        b.flush();
+    });
+}


### PR DESCRIPTION
Changes:
1. Adding the kprintln!/kprint! macros.
2. Adding a spinlock to hold a global, so that those work.

This also then requires `const fn` and so makes things nightly-only. For
now!

r? @ashleygwilliams 
